### PR TITLE
Fix global variable declaration in parallax script

### DIFF
--- a/parallax-template/js/main.js
+++ b/parallax-template/js/main.js
@@ -1,4 +1,4 @@
-oldScroll=0;
+let oldScroll = 0;
 $(window).scroll(function () {
 	var scrollTop = $(this).scrollTop();
 	var windowBottom=window.scrollY + window.innerHeight;


### PR DESCRIPTION
## Summary
- declare `oldScroll` using `let` to avoid implicit global

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc50bbe7083329a448cc4072dbf87